### PR TITLE
Feat: added support for preload image

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   - [Adding More Pages](#addingMorePages)
   - [Navigation via Front Matter](#navigationViaFrontMatter)
   - [Built-in Astro components](#builtinastrocomponents)
+  - [Preloading Images](#preloadingimages)
   - [CSS](#css)
   - [Adding View Transitions](#addingViewTransitions)
 
@@ -219,13 +220,12 @@ import Landing from "@components/Landing.astro";
 ---
 
 <BaseLayout
-  title="About"
-  description="Meta description for the page"
-  preloadImg="/assets/images/cabinets2.jpg"
+  // props
 >
   // Use the <Landing /> component
   <Landing 
     title="About Us" // pass a `title` prop to the component
+    image={optimizedImage} // pass an 'image' prop to the component
   />
 ```
 
@@ -371,6 +371,25 @@ This code will be inserted into the `<slot />` component in BaseLayout.astro.
 This kit demonstrates the use of the built-in `<Picture />` component, [for which you can read the documentation here](https://docs.astro.build/en/guides/images/#picture-). However, not all native HTML `<picture>` elements from CodeStitch blocks have been replaced with Astro's `<Picture />` components. CodeStich users will have to decide which one they want to use:
  * CodeStich blocks already have fully-functionning `<picture>` elements that perform very well. However, the developper will have to do a time-consumming job with resizing and reformatting assets.
  * Astro's `<Picture />` components must be manually written to replace stitches. On the other hand, they automatically process and optimize assets, which allows the developper to skip the resizing and reformatting preparation work.
+
+
+<a name="preloadingimages"></a>
+
+### Preloading images
+THis kit takes advantage of the [preload attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload) to fetch images above the fold with higher priority, resulting in improved performances and reducing flashes of unstyled content. Preloaded images are used on the index page for the hero image as well as on all other pages in the Landing component.
+
+You will notice this snippet at the top of every `.astro` page:
+
+```jsx
+---
+// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import {getOptimizedImage} from "../js/utils"
+import landingImage from "../assets/images/landing.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
+const optimizedImage = await getOptimizedImage(landingImage)
+---
+```
+
+You only need to change the path of the asset you want to preload. The rest is managed behind the scenes.
 
 <a name="css"></a>
 

--- a/src/components/Landing.astro
+++ b/src/components/Landing.astro
@@ -1,15 +1,19 @@
 ---
 import Picture from "astro/components/Picture.astro"
-import landingImage from "../assets/images/cabinets2.jpg" // The asset must be imported from src
-const { title } = Astro.props
+
+// Receiving and destructuring props from the .astro pages
+const { title, image } = Astro.props
 ---
 
 <section id="int-hero">
 <h1 id="home-h">{title}</h1>
 
 <!-- standard <picture> attributes are supported. Set loading to lazy for assets below the fold -->
+ <!-- Note: because we use the getImage function to generate an optimized image, we need to use special properties. More info on [the getImage() page](https://docs.astro.build/en/guides/images/#generating-images-with-getimage) -->
 <Picture 
-    src={landingImage}
+    src={image.src}
+    width={image.attributes.width}
+    height={image.attributes.height}
     formats={['avif', 'webp']} 
     alt="A description of my image."
     aria-hidden="true" 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,0 +1,13 @@
+import { getImage } from "astro:assets";
+
+export async function getOptimizedImage(image) {
+  const optimizedImage = await getImage({
+    src: image,
+    format: "webp",
+  });
+
+  return optimizedImage
+}
+
+// Learn more agout the getImage() function here
+// https://docs.astro.build/en/guides/images/#generating-images-with-getimage

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,12 +1,12 @@
 ---
-import { ViewTransitions } from "astro:transitions";
 import client from "../data/client.json";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import "../styles/root.less";
 import "../styles/dark.less";
 
-const { description, title } = Astro.props;
+// Receiving and destructuring props from the .astro pages
+const { description, title, preloadedImage } = Astro.props;
 ---
 
 <!-- A fully fleshed-out <head>, dynamically changing based on client.json and the page front matter -->
@@ -19,6 +19,9 @@ const { description, title } = Astro.props;
     <meta name="description" content={description} />
     <meta name="keywords" content="" />
     <link rel="canonical" href={`https://${client.domain}${Astro.url.pathname}`} />
+    
+    <!-- Preloads the image passed as a prop -->
+    <link rel="preload" href={preloadedImage.src} as="image" />
 
     <!--Social Media Display-->
     <meta property="og:title" content={title} />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,11 +2,21 @@
 import BaseLayout from "..//layouts/BaseLayout.astro";
 import CTA from "../components/CTA.astro";
 import Landing from "../components/Landing.astro";
+
+import landingImage from "../assets/images/cabinets2.jpg" // The asset must be imported from src
+
+// using the getImage Astro function to optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import { getImage } from "astro:assets";
+const optimizedImage = await getImage({
+  src: landingImage,
+  format: "webp"
+});
 ---
 
 <BaseLayout
   title="About"
   description="Meta description for the page"
+  preloadedImage = {optimizedImage}
 >
   <!-- ============================================ -->
   <!--                    LANDING                   -->
@@ -14,6 +24,7 @@ import Landing from "../components/Landing.astro";
 
   <Landing 
     title="About Us"
+    image={optimizedImage}
   />
 
   <!-- ============================================ -->

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -5,7 +5,7 @@ import Landing from "../components/Landing.astro";
 
 // Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
 import {getOptimizedImage} from "../js/utils"
-import landingImage from "../assets/images/cabinets2.jpg" // The asset must be imported from src
+import landingImage from "../assets/images/cabinets2.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
 const optimizedImage = await getOptimizedImage(landingImage)
 ---
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,14 +3,10 @@ import BaseLayout from "..//layouts/BaseLayout.astro";
 import CTA from "../components/CTA.astro";
 import Landing from "../components/Landing.astro";
 
+// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import {getOptimizedImage} from "../js/utils"
 import landingImage from "../assets/images/cabinets2.jpg" // The asset must be imported from src
-
-// using the getImage Astro function to optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
-import { getImage } from "astro:assets";
-const optimizedImage = await getImage({
-  src: landingImage,
-  format: "webp"
-});
+const optimizedImage = await getOptimizedImage(landingImage)
 ---
 
 <BaseLayout

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -3,18 +3,28 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import client from "../data/client.json";
 import Landing from "../components/Landing.astro";
 
+import landingImage from "../assets/images/cabinets2.jpg" // The asset must be imported from src
+
+// using the getImage Astro function to optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import { getImage } from "astro:assets";
+const optimizedImage = await getImage({
+  src: landingImage,
+  format: "webp"
+});
 ---
 
 <BaseLayout
-  title="Contact"
+  title="About"
   description="Meta description for the page"
+  preloadedImage = {optimizedImage}
 >
   <!-- ============================================ -->
   <!--                    LANDING                   -->
   <!-- ============================================ -->
 
   <Landing 
-    title="Contact"
+    title="Projects"
+    image={optimizedImage}
   />
 
   <!-- ============================================ -->

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -5,7 +5,7 @@ import Landing from "../components/Landing.astro";
 
 // Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
 import {getOptimizedImage} from "../js/utils"
-import landingImage from "../assets/images/cabinets2.jpg" // The asset must be imported from src
+import landingImage from "../assets/images/cabinets2.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
 const optimizedImage = await getOptimizedImage(landingImage)
 ---
 

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -3,14 +3,10 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import client from "../data/client.json";
 import Landing from "../components/Landing.astro";
 
+// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import {getOptimizedImage} from "../js/utils"
 import landingImage from "../assets/images/cabinets2.jpg" // The asset must be imported from src
-
-// using the getImage Astro function to optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
-import { getImage } from "astro:assets";
-const optimizedImage = await getImage({
-  src: landingImage,
-  format: "webp"
-});
+const optimizedImage = await getOptimizedImage(landingImage)
 ---
 
 <BaseLayout

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,7 @@ import CTA from "../components/CTA.astro";
 
 // Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
 import {getOptimizedImage} from "../js/utils"
-import landingImage from "../assets/images/landing.jpg" // The asset must be imported from src
+import landingImage from "../assets/images/landing.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
 const optimizedImage = await getOptimizedImage(landingImage)
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,22 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import CTA from "../components/CTA.astro";
+
+import { getImage } from "astro:assets";
+
+import image from "../assets/images/landing.jpg";
+const optimizedImage = await getImage({
+  src: image,
+  format: "webp",
+  width: 500, // resize optional
+  height: 500, // resize optional
+});
 ---
 
 <BaseLayout
   title="Pixel Perfect Websites"
   description="Meta description for the page"
+  preloadedImage = {optimizedImage}
 >
   <!-- ============================================ -->
   <!--                    Hero                      -->
@@ -46,7 +57,7 @@ allows for repeated components, centralized data and greater room to scale as yo
       <img
         aria-hidden="true"
         decoding="async"
-        src="/assets/images/landing.jpg"
+        src={optimizedImage.src}
         alt="new home"
         width="2500"
         height="1667"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,15 +2,10 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import CTA from "../components/CTA.astro";
 
-import { getImage } from "astro:assets";
-
-import image from "../assets/images/landing.jpg";
-const optimizedImage = await getImage({
-  src: image,
-  format: "webp",
-  width: 500, // resize optional
-  height: 500, // resize optional
-});
+// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import {getOptimizedImage} from "../js/utils"
+import landingImage from "../assets/images/landing.jpg" // The asset must be imported from src
+const optimizedImage = await getOptimizedImage(landingImage)
 ---
 
 <BaseLayout

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -5,7 +5,7 @@ import Landing from "../components/Landing.astro";
 
 // Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
 import {getOptimizedImage} from "../js/utils"
-import landingImage from "../assets/images/cabinets2.jpg" // The asset must be imported from src
+import landingImage from "../assets/images/cabinets2.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
 const optimizedImage = await getOptimizedImage(landingImage)
 ---
 

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,12 +1,22 @@
 ---
-import BaseLayout from "../layouts/BaseLayout.astro";
+import BaseLayout from "..//layouts/BaseLayout.astro";
 import CTA from "../components/CTA.astro";
 import Landing from "../components/Landing.astro";
+
+import landingImage from "../assets/images/cabinets2.jpg" // The asset must be imported from src
+
+// using the getImage Astro function to optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import { getImage } from "astro:assets";
+const optimizedImage = await getImage({
+  src: landingImage,
+  format: "webp"
+});
 ---
 
 <BaseLayout
-  title="Projects"
+  title="About"
   description="Meta description for the page"
+  preloadedImage = {optimizedImage}
 >
   <!-- ============================================ -->
   <!--                    LANDING                   -->
@@ -14,6 +24,7 @@ import Landing from "../components/Landing.astro";
 
   <Landing 
     title="Projects"
+    image={optimizedImage}
   />
 
   <!-- ============================================ -->

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -3,14 +3,10 @@ import BaseLayout from "..//layouts/BaseLayout.astro";
 import CTA from "../components/CTA.astro";
 import Landing from "../components/Landing.astro";
 
+// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import {getOptimizedImage} from "../js/utils"
 import landingImage from "../assets/images/cabinets2.jpg" // The asset must be imported from src
-
-// using the getImage Astro function to optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
-import { getImage } from "astro:assets";
-const optimizedImage = await getImage({
-  src: landingImage,
-  format: "webp"
-});
+const optimizedImage = await getOptimizedImage(landingImage)
 ---
 
 <BaseLayout

--- a/src/pages/reviews.astro
+++ b/src/pages/reviews.astro
@@ -5,7 +5,7 @@ import Landing from "../components/Landing.astro";
 
 // Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
 import {getOptimizedImage} from "../js/utils"
-import landingImage from "../assets/images/cabinets2.jpg" // The asset must be imported from src
+import landingImage from "../assets/images/cabinets2.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
 const optimizedImage = await getOptimizedImage(landingImage)
 ---
 

--- a/src/pages/reviews.astro
+++ b/src/pages/reviews.astro
@@ -3,14 +3,10 @@ import BaseLayout from "..//layouts/BaseLayout.astro";
 import CTA from "../components/CTA.astro";
 import Landing from "../components/Landing.astro";
 
+// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import {getOptimizedImage} from "../js/utils"
 import landingImage from "../assets/images/cabinets2.jpg" // The asset must be imported from src
-
-// using the getImage Astro function to optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
-import { getImage } from "astro:assets";
-const optimizedImage = await getImage({
-  src: landingImage,
-  format: "webp"
-});
+const optimizedImage = await getOptimizedImage(landingImage)
 ---
 
 <BaseLayout

--- a/src/pages/reviews.astro
+++ b/src/pages/reviews.astro
@@ -1,19 +1,30 @@
 ---
-import BaseLayout from "../layouts/BaseLayout.astro";
+import BaseLayout from "..//layouts/BaseLayout.astro";
 import CTA from "../components/CTA.astro";
 import Landing from "../components/Landing.astro";
+
+import landingImage from "../assets/images/cabinets2.jpg" // The asset must be imported from src
+
+// using the getImage Astro function to optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
+import { getImage } from "astro:assets";
+const optimizedImage = await getImage({
+  src: landingImage,
+  format: "webp"
+});
 ---
 
 <BaseLayout
-  title="Reviews"
+  title="About"
   description="Meta description for the page"
+  preloadedImage = {optimizedImage}
 >
   <!-- ============================================ -->
   <!--                    LANDING                   -->
   <!-- ============================================ -->
 
   <Landing 
-    title="Reviews"
+    title="Projects"
+    image={optimizedImage}
   />
 
   <!-- ============================================ -->


### PR DESCRIPTION
This kit takes advantage of the [preload attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload) to fetch images above the fold with higher priority, resulting in improved performances and reducing flashes of unstyled content. Preloaded images are used on the index page for the hero image as well as on all other pages in the Landing component.

You will notice this snippet at the top of every `.astro` page:

```jsx
---
// Optimize our landing image and pass it as props to the BaseLayout (for preloading) and Landing (for rendering)
import {getOptimizedImage} from "../js/utils"
import landingImage from "../assets/images/landing.jpg" // <-- THE PATH TO THE ASSET YOU WANT TO PRELOAD - The asset must live in src
const optimizedImage = await getOptimizedImage(landingImage)
---
```

You only need to change the path of the asset you want to preload (e.g. `"../assets/images/landing.jpg"`). The rest is managed behind the scenes.